### PR TITLE
Graphql init

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [com.taoensso/timbre "4.10.0"]
 
                  ;; graphql
-                 [re-graph "0.1.12"]
+                 [re-graph "0.1.13" :exclusions [re-graph.hato]]
                  [district0x/graphql-query "1.0.5"]
 
                  ;; These has to be explicitly specified as lein does not

--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,6 @@
 
                  ;; clojurescript and tooling
                  [org.clojure/clojurescript "1.10.520" :scope "provided"]
-                 [binaryage/devtools "1.0.0"]
-                 [day8.re-frame/re-frame-10x "0.6.5"]
                  [thheller/shadow-cljs "2.8.94"]
 
                  ;; react
@@ -33,4 +31,7 @@
 
   :source-paths ["src"]
 
-  :profiles {:dev {}})
+  :profiles {:dev
+             {:dependencies [[binaryage/devtools "1.0.0"]
+                             [day8.re-frame/re-frame-10x "0.6.5"]
+                             [day8.re-frame/tracing "0.5.5"]]}})

--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,9 @@
                  [re-graph "0.1.13" :exclusions [re-graph.hato]]
                  [district0x/graphql-query "1.0.5"]
 
+                 ;; json encoder/decoder
+                 [com.cognitect/transit-cljs "0.8.264"]
+
                  ;; These has to be explicitly specified as lein does not
                  ;; properly manage dependency version conflicts :
                  ;; https://github.com/thheller/shadow-cljs/issues/488#issuecomment-486732296

--- a/src/dashboard/components/dashboard.cljs
+++ b/src/dashboard/components/dashboard.cljs
@@ -1,0 +1,24 @@
+(ns dashboard.components.dashboard
+  (:require [reagent.core :as r]
+            [reagent.dom :as rdom]
+            [taoensso.timbre :as log
+             :refer-macros [log trace debug info warn error fatal report
+                            logf tracef debugf infof warnf errorf fatalf reportf
+                            spy get-env]]
+            ["bloomer" :refer (Tile Hero HeroBody Title Subtitle Notification)]
+            ["react-router-dom" :refer (NavLink)]
+            [dashboard.components.search :refer [search]]))
+
+(defn dashboard
+  []
+  [:div
+   [:> Hero {:isbold "true" :iscolor "true" :issize "small"}
+    [:> HeroBody
+     [:> Title "Dashboard"]
+     [:> Subtitle "Uptime"]]]
+   [:div.tiles
+    [:> Tile {:isancestor "true" :hastextalign "centered"}
+     [:> NavLink {:class "tile is-parent is-4" :to "/adapters"}
+      [:> Tile {:ischild "true" :class "box"}
+       [:> Title "stats.adapter_count"]
+       [:> Subtitle "Adapters"]]]]]])

--- a/src/dashboard/core.cljs
+++ b/src/dashboard/core.cljs
@@ -1,6 +1,7 @@
 (ns dashboard.core
   (:require [reagent.core :as r]
             [reagent.dom :as rdom]
+            [re-frame.core :as rf]
             [taoensso.timbre :as log
              :refer-macros [log trace debug info warn error fatal report
                             logf tracef debugf infof warnf errorf fatalf reportf
@@ -8,7 +9,9 @@
             ["bloomer" :refer (Navbar Container NavbarStart NavbarBrand NavbarItem
                                       Icon MenuList MenuLabel Menu Field NavbarEnd)]
             ["react-router-dom" :refer (Route NavLink) :rename {BrowserRouter Router}]
-            [dashboard.components.search :refer [search]]))
+            [dashboard.components.search :refer [search]]
+            [dashboard.components.dashboard :refer [dashboard]]
+            [dashboard.events.init :as init]))
 
 (enable-console-print!)
 
@@ -17,6 +20,9 @@
 ;; define your app data so that it doesn't get over-written on reload
 
 (defonce app-state (atom {:text "Hello world!"}))
+
+;; Imported components
+(def Dashboard (r/reactify-component dashboard))
 
 (defn nav-bar
   "Top nav bar"
@@ -93,7 +99,7 @@
 (defn content-container
   []
   [:div#content-container.column.is-10
-   [:> Route {:path "/" :exact true}]
+   [:> Route {:path "/" :exact true :component Dashboard}]
    [:> Route {:path "/adapters"}]
    [:> Route {:path "/history"}]
    [:> Route {:path "/users"}]
@@ -120,14 +126,15 @@
     [content-body]]])
 
 (defn start
-    "Mounts the application root component in the DOM."
-    []
-    (rdom/render [dashboard-app] (js/document.getElementById "app")))
+  "Mounts the application root component in the DOM."
+  []
+  (rdom/render [dashboard-app] (js/document.getElementById "app")))
 
 (defn ^:export init
   "Dashboard entrypoint which is called only once when `index.html` loads.
   It must be exported so it is available even in :advanced release builds."
   []
+  (rf/dispatch-sync [::init/init])
   (start))
 
 (defn on-js-reload []

--- a/src/dashboard/events/init.cljs
+++ b/src/dashboard/events/init.cljs
@@ -5,6 +5,7 @@
             [taoensso.timbre :as log]
             [day8.re-frame.tracing :refer-macros [fn-traced]]))
 
+(def ^:const graphql-endpoint "https://public.yetibot.com/graphql")
 ;--------------------------------------------------------------
 ; Initialization
 ;--------------------------------------------------------------
@@ -21,7 +22,8 @@
  (fn-traced [_ _]
             {:dispatch [::re-graph/init
                         {:http
-                         {:url "https://public.yetibot.com/graphql"}
+                         {:url graphql-endpoint
+                          :impl {:with-credentials? false}}
                          :ws
                          {:url nil}}]}))
 

--- a/src/dashboard/events/init.cljs
+++ b/src/dashboard/events/init.cljs
@@ -1,0 +1,50 @@
+(ns dashboard.events.init
+  (:require [re-frame.core :as rf]
+            [re-graph.core :as re-graph]
+            [dashboard.graphql.queries :as queries]
+            [taoensso.timbre :as log]))
+
+;--------------------------------------------------------------
+; Initialization
+;--------------------------------------------------------------
+(rf/reg-event-fx
+ ::init
+ (fn [{:keys [db]} _]
+   {:dispatch [::init-re-graph]}))
+
+;--------------------------------------------------------------
+; Re-graph initialization
+;--------------------------------------------------------------
+(rf/reg-event-fx
+ ::init-re-graph
+ (fn [_ _]
+   {:dispatch [::re-graph/init
+               {:http
+                {:url "https://public.yetibot.com/graphql"}}]}))
+
+;--------------------------------------------------------------
+; Dashboard
+;--------------------------------------------------------------
+(rf/reg-event-db
+ :dashboard/stats
+ (fn [_ [_ timezone-offset-hours]]
+   {:dispatch [::re-graph/query
+               queries/stats
+               {:timezone_offset_hours timezone-offset-hours}
+               [:dashboard/on-stats]]}))
+
+(rf/reg-event-db
+ :dashboard/on-stats
+ (fn [db [_ {:keys [data errors] :as payload}]]
+   (if errors
+     {:dispatch [::on-error :dashboard/stats payload]}
+     {:db (assoc db :dashboard/stats data)})))
+
+;--------------------------------------------------------------
+; Generic error-handling
+;--------------------------------------------------------------
+(rf/reg-event-db
+ ::on-error
+ (fn [db [{:keys [event-id & parameters]}]]
+   {:db (assoc db :error/event-id event-id
+               :error/parameters parameters)}))

--- a/src/dashboard/graphql/queries.cljs
+++ b/src/dashboard/graphql/queries.cljs
@@ -1,0 +1,17 @@
+(ns dashboard.graphql.queries)
+
+(def stats
+  "query stats($timezone_offset_hours: Int!) {
+    stats(timezone_offset_hours: $timezone_offset_hours) {
+      uptime
+      adapter_count
+      user_count
+      command_count_today
+      command_count
+      history_count
+      history_count_today
+      alias_count
+      observer_count
+      cron_count
+    }
+  }")


### PR DESCRIPTION
This PR implements the `re-graph` lib initial _setup_ and _configuration_. It includes among others the fetching of the **dashboard statistics** from the _graphql_ service endpoint and saving the retrieved data in the local `re-frame.db/app-db`